### PR TITLE
다짐 기능 구현

### DIFF
--- a/src/main/java/plannery/flora/component/SecurityUtils.java
+++ b/src/main/java/plannery/flora/component/SecurityUtils.java
@@ -1,0 +1,36 @@
+package plannery.flora.component;
+
+import static plannery.flora.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static plannery.flora.exception.ErrorCode.NO_AUTHORITY;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import plannery.flora.entity.MemberEntity;
+import plannery.flora.exception.CustomException;
+import plannery.flora.repository.MemberRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityUtils {
+
+  private final MemberRepository memberRepository;
+
+  /**
+   * 본인 확인
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return MemberEntity
+   */
+  public MemberEntity validateUserDetails(UserDetails userDetails, Long memberId) {
+    MemberEntity member = memberRepository.findByEmail(userDetails.getUsername())
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    if (!member.getId().equals(memberId)) {
+      throw new CustomException(NO_AUTHORITY);
+    }
+
+    return member;
+  }
+}

--- a/src/main/java/plannery/flora/controller/PromiseController.java
+++ b/src/main/java/plannery/flora/controller/PromiseController.java
@@ -1,0 +1,88 @@
+package plannery.flora.controller;
+
+import static plannery.flora.enums.ResponseMessage.SUCCESS_PROMISE_CREATE;
+import static plannery.flora.enums.ResponseMessage.SUCCESS_PROMISE_DELETE;
+import static plannery.flora.enums.ResponseMessage.SUCCESS_PROMISE_UPDATE;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plannery.flora.dto.promise.PromiseDto;
+import plannery.flora.service.PromiseService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/{memberId}/promise")
+public class PromiseController {
+
+  private final PromiseService promiseService;
+
+  /**
+   * 다짐 생성
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param promiseDto  : 내용
+   * @return "다짐 생성 완료"
+   */
+  @PostMapping
+  public ResponseEntity<String> createPromise(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @RequestBody PromiseDto promiseDto) {
+    promiseService.createPromise(userDetails, memberId, promiseDto);
+
+    return ResponseEntity.ok(SUCCESS_PROMISE_CREATE.getMessage());
+  }
+
+  /**
+   * 다짐 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return PromiseDto : 내용
+   */
+  @GetMapping
+  public ResponseEntity<PromiseDto> getPromise(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId) {
+    return ResponseEntity.ok(promiseService.getPromise(userDetails, memberId));
+  }
+
+  /**
+   * 다짐 수정
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param promiseDto  : 내용
+   * @return "다짐 수정 완료"
+   */
+  @PutMapping
+  public ResponseEntity<String> updatePromise(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @RequestBody PromiseDto promiseDto) {
+    promiseService.updatePromise(userDetails, memberId, promiseDto);
+
+    return ResponseEntity.ok(SUCCESS_PROMISE_UPDATE.getMessage());
+  }
+
+  /**
+   * 다짐 삭제
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return "다짐 삭제 완료"
+   */
+  @DeleteMapping
+  public ResponseEntity<String> deletePromise(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId) {
+    promiseService.deletePromise(userDetails, memberId);
+
+    return ResponseEntity.ok(SUCCESS_PROMISE_DELETE.getMessage());
+  }
+}

--- a/src/main/java/plannery/flora/dto/promise/PromiseDto.java
+++ b/src/main/java/plannery/flora/dto/promise/PromiseDto.java
@@ -1,0 +1,15 @@
+package plannery.flora.dto.promise;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PromiseDto {
+
+  private String content;
+}

--- a/src/main/java/plannery/flora/entity/PromiseEntity.java
+++ b/src/main/java/plannery/flora/entity/PromiseEntity.java
@@ -1,0 +1,38 @@
+package plannery.flora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "promise")
+public class PromiseEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(columnDefinition = "TEXT")
+  private String content;
+
+  @OneToOne
+  @JoinColumn(name = "member_id", nullable = false, unique = true)
+  private MemberEntity member;
+
+  public void updateContent(String newContent) {
+    this.content = newContent;
+  }
+}

--- a/src/main/java/plannery/flora/enums/ResponseMessage.java
+++ b/src/main/java/plannery/flora/enums/ResponseMessage.java
@@ -12,7 +12,10 @@ public enum ResponseMessage {
   SUCCESS_IMAGE_DELETE("이미지 파일 삭제 완료"),
   SUCCESS_PASSWORD_CHANGE("비밀번호 변경 완료"),
   SUCCESS_SEND_PASSWORD_CHANGE("비밀번호 변경 링크 전송 완료"),
-  SUCCESS_MEMBER_DELETE("회원 탈퇴 완료");
+  SUCCESS_MEMBER_DELETE("회원 탈퇴 완료"),
+  SUCCESS_PROMISE_CREATE("다짐 생성 완료"),
+  SUCCESS_PROMISE_UPDATE("다짐 수정 완료"),
+  SUCCESS_PROMISE_DELETE("다짐 삭제 완료");
 
   private final String message;
 }

--- a/src/main/java/plannery/flora/exception/ErrorCode.java
+++ b/src/main/java/plannery/flora/exception/ErrorCode.java
@@ -20,7 +20,8 @@ public enum ErrorCode {
   FAILED_TO_DELETE_IMAGE(500, "이미지 삭제에 실패했습니다."),
   IMAGE_NOT_FOUND(404, "이미지를 조회하지 못했습니다."),
   SAME_PASSWORD(400, "현재 비밀번호와 새 비밀번호가 같습니다."),
-  FAIL_EMAIL_SEND(500, "이메일 전송에 실패했습니다.");
+  FAIL_EMAIL_SEND(500, "이메일 전송에 실패했습니다."),
+  PROMISE_NOT_FOUND(404, "다짐 내용이 존재하지 않습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plannery/flora/repository/PromiseRepository.java
+++ b/src/main/java/plannery/flora/repository/PromiseRepository.java
@@ -1,0 +1,15 @@
+package plannery.flora.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import plannery.flora.entity.PromiseEntity;
+
+@Repository
+public interface PromiseRepository extends JpaRepository<PromiseEntity, Long> {
+
+  @Query("SELECT p FROM PromiseEntity p WHERE p.member.id = :memberId")
+  Optional<PromiseEntity> findByMemberId(@Param("memberId") Long memberId);
+}

--- a/src/main/java/plannery/flora/service/ImageService.java
+++ b/src/main/java/plannery/flora/service/ImageService.java
@@ -4,7 +4,6 @@ import static plannery.flora.enums.ImageType.IMAGE_GALLERY;
 import static plannery.flora.enums.ImageType.IMAGE_PROFILE;
 import static plannery.flora.exception.ErrorCode.IMAGE_NOT_FOUND;
 import static plannery.flora.exception.ErrorCode.MEMBER_NOT_FOUND;
-import static plannery.flora.exception.ErrorCode.NO_AUTHORITY;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import plannery.flora.component.S3ImageUpload;
+import plannery.flora.component.SecurityUtils;
 import plannery.flora.entity.ImageEntity;
 import plannery.flora.entity.MemberEntity;
 import plannery.flora.enums.ImageType;
@@ -28,6 +28,7 @@ public class ImageService {
   private final S3ImageUpload s3ImageUpload;
   private final MemberRepository memberRepository;
   private final ImageRepository imageRepository;
+  private final SecurityUtils securityUtils;
 
   @Value("${app.default.profile.url}")
   private String defaultProfileUrl;
@@ -74,12 +75,11 @@ public class ImageService {
    */
   public String uploadImage(UserDetails userDetails, MultipartFile file, Long memberId,
       ImageType imageType) {
-    checkUserDetails(userDetails, memberId);
+    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
 
     ImageEntity imageEntity = imageRepository.findByMemberIdAndImageType(memberId, imageType)
         .orElseGet(() -> ImageEntity.builder()
-            .member(memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND)))
+            .member(member)
             .imageType(imageType)
             .build());
 
@@ -108,7 +108,7 @@ public class ImageService {
    * @return 이미지 URL
    */
   public String getImage(UserDetails userDetails, Long memberId, ImageType imageType) {
-    checkUserDetails(userDetails, memberId);
+    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
 
     return imageRepository.findByMemberIdAndImageType(memberId, imageType)
         .map(ImageEntity::getImageUrl)
@@ -122,7 +122,7 @@ public class ImageService {
    * @param imageType 이미지 타입 : IMAGE_PROFILE, IMAGE_GALLERY
    */
   public void deleteImage(UserDetails userDetails, Long memberId, ImageType imageType) {
-    checkUserDetails(userDetails, memberId);
+    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
 
     ImageEntity imageEntity = imageRepository.findByMemberIdAndImageType(memberId, imageType)
         .orElseThrow(() -> new CustomException(IMAGE_NOT_FOUND));
@@ -139,15 +139,6 @@ public class ImageService {
         imageEntity.updateImage(defaultGalleryUrl);
         imageRepository.save(imageEntity);
       }
-    }
-  }
-
-  private void checkUserDetails(UserDetails userDetails, Long memberId) {
-    MemberEntity member = memberRepository.findByEmail(userDetails.getUsername())
-        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-    if (!member.getId().equals(memberId)) {
-      throw new CustomException(NO_AUTHORITY);
     }
   }
 }

--- a/src/main/java/plannery/flora/service/PromiseService.java
+++ b/src/main/java/plannery/flora/service/PromiseService.java
@@ -1,0 +1,92 @@
+package plannery.flora.service;
+
+import static plannery.flora.exception.ErrorCode.PROMISE_NOT_FOUND;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plannery.flora.component.SecurityUtils;
+import plannery.flora.dto.promise.PromiseDto;
+import plannery.flora.entity.MemberEntity;
+import plannery.flora.entity.PromiseEntity;
+import plannery.flora.exception.CustomException;
+import plannery.flora.repository.PromiseRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PromiseService {
+
+  private final PromiseRepository promiseRepository;
+  private final SecurityUtils securityUtils;
+
+  /**
+   * 다짐 생성
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param promiseDto: content
+   */
+  @Transactional
+  public void createPromise(UserDetails userDetails, Long memberId, PromiseDto promiseDto) {
+    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
+
+    PromiseEntity promise = PromiseEntity.builder()
+        .member(member)
+        .content(promiseDto.getContent())
+        .build();
+
+    promiseRepository.save(promise);
+  }
+
+  /**
+   * 다짐 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return PromiseDto : 내용
+   */
+  public PromiseDto getPromise(UserDetails userDetails, Long memberId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    Optional<PromiseEntity> promise = promiseRepository.findByMemberId(memberId);
+
+    return promise.map(promiseEntity -> PromiseDto.builder()
+        .content(promiseEntity.getContent())
+        .build()).orElse(PromiseDto.builder().content("").build());
+  }
+
+  /**
+   * 다짐 수정
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param promiseDto  : 내용
+   */
+  @Transactional
+  public void updatePromise(UserDetails userDetails, Long memberId, PromiseDto promiseDto) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    PromiseEntity promise = promiseRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new CustomException(PROMISE_NOT_FOUND));
+
+    promise.updateContent(promiseDto.getContent());
+  }
+
+  /**
+   * 다짐 삭제
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   */
+  @Transactional
+  public void deletePromise(UserDetails userDetails, Long memberId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    PromiseEntity promise = promiseRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new CustomException(PROMISE_NOT_FOUND));
+
+    promiseRepository.deleteById(promise.getId());
+  }
+}


### PR DESCRIPTION
# 변경사항
### AS-IS
- **다짐 기능 부재**

- **본인 확인 로직 중복**

<br><br>

### TO-BE
**다짐 기능 구현**
- **PromiseController & PromiseService**
  - **createPromise()**
    - 다짐 생성
    - userDetails, memberId, promiseDto(content)
  - **getPromise()**
    - 다짐 조회
    - userDetails, memberId
    - return PromiseDto(content)
  - **updatePromise()**
    - 다짐 수정
    - userDetails, memberId, promiseDto(content)
  - **deletePromise()**
    - 다짐 삭제
    - userDetails, memberId


**본인 확인 로직 util화**
- **SecurityUtils**
  - **validateUserDetails()**
    - userDetails, memberId
    - return MemberEntity


<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드