### PR TITLE
다짐 기능 수정

### DIFF
--- a/src/main/java/plannery/flora/entity/MemberEntity.java
+++ b/src/main/java/plannery/flora/entity/MemberEntity.java
@@ -42,6 +42,9 @@ public class MemberEntity extends BaseEntity {
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ImageEntity> images;
 
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<PromiseEntity> promises;
+
   public void updatePassword(String newPassword) {
     this.password = newPassword;
   }

--- a/src/main/java/plannery/flora/entity/PromiseEntity.java
+++ b/src/main/java/plannery/flora/entity/PromiseEntity.java
@@ -6,7 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,8 +28,8 @@ public class PromiseEntity extends BaseEntity {
   @Column(columnDefinition = "TEXT")
   private String content;
 
-  @OneToOne
-  @JoinColumn(name = "member_id", nullable = false, unique = true)
+  @ManyToOne
+  @JoinColumn(name = "member_id")
   private MemberEntity member;
 
   public void updateContent(String newContent) {

--- a/src/main/java/plannery/flora/exception/ErrorCode.java
+++ b/src/main/java/plannery/flora/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
   IMAGE_NOT_FOUND(404, "이미지를 조회하지 못했습니다."),
   SAME_PASSWORD(400, "현재 비밀번호와 새 비밀번호가 같습니다."),
   FAIL_EMAIL_SEND(500, "이메일 전송에 실패했습니다."),
-  PROMISE_NOT_FOUND(404, "다짐 내용이 존재하지 않습니다.");
+  PROMISE_NOT_FOUND(404, "다짐 내용이 존재하지 않습니다."),
+  PROMISE_EXISTS(400, "다짐이 이미 존재합니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plannery/flora/service/PromiseService.java
+++ b/src/main/java/plannery/flora/service/PromiseService.java
@@ -1,5 +1,6 @@
 package plannery.flora.service;
 
+import static plannery.flora.exception.ErrorCode.PROMISE_EXISTS;
 import static plannery.flora.exception.ErrorCode.PROMISE_NOT_FOUND;
 
 import java.util.Optional;
@@ -31,6 +32,11 @@ public class PromiseService {
   @Transactional
   public void createPromise(UserDetails userDetails, Long memberId, PromiseDto promiseDto) {
     MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
+
+    Optional<PromiseEntity> existingPromise = promiseRepository.findByMemberId(memberId);
+    if (existingPromise.isPresent()) {
+      throw new CustomException(PROMISE_EXISTS);
+    }
 
     PromiseEntity promise = PromiseEntity.builder()
         .member(member)


### PR DESCRIPTION
# 변경사항
### AS-IS
- **다짐이 존재하는 상태에서 회원 탈퇴 시 에러 발생**
```java
2024-09-12 21:20:33.398] ERROR 78032 --- [
        http-nio-8080-exec-6 ] o.h.e.j.s.SqlExceptionHelper : (conn=174) Cannot delete or update a parent row: a foreign key constraint fails (flora.promise, CONSTRAINT FKdn3dm2pqgum1302mitah7uuv8 FOREIGN KEY (member_id) REFERENCES member (id))
2024-09-12 21:20:33.401] ERROR 78035 --- [
        http-nio-8080-exec-6 ] o.a.c.c.C.[.[.[.[dispatcherServlet] : Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: org.springframework.dao.DataIntegrityViolationException: could not execute statement [(conn=174) Cannot delete or update a parent row: a foreign key constraint fails (flora.promise, CONSTRAINT FKdn3dm2pqgum1302mitah7uuv8 FOREIGN KEY (member_id) REFERENCES member (id))] [/* delete for plannery.flora.entity.MemberEntity */delete from member where id=?]; SQL [/* delete for plannery.flora.entity.MemberEntity */delete from member where id=?]; constraint [null]] with root cause
java.sql.SQLIntegrityConstraintViolationException: (conn=174) Cannot delete or update a parent row: a foreign key constraint fails (flora.promise, CONSTRAINT FKdn3dm2pqgum1302mitah7uuv8 FOREIGN KEY (member_id) REFERENCES member (id))
```


<br><br>

### TO-BE
**SQL 에러 해결**
- **MemberEntity**
  - List<PromiseEntity>
  - OneToMany 관계 설정
- **PromiseEntity**
  - MemberEntity와의 관계 : OneToOne -> ManyToOne
  - 수정 이유 : MemberEntity를 삭제하려고 할 때 promise 테이블의 외래 키 제약 조건 때문에 삭제 실패
- **PromiseService**
  - **createPromise()**
    - 다짐이 이미 존재한다면 더 이상 생성할 수 없도록 CustomException을 throw
    - 더이상 OneToOne 관계가 아니기 때문에 유일성을 체크해야 함


<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드