### PR TITLE
이벤트 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/plannery/flora/controller/DiaryController.java
+++ b/src/main/java/plannery/flora/controller/DiaryController.java
@@ -4,6 +4,7 @@ import static plannery.flora.enums.ResponseMessage.SUCCESS_DIARY_CREATE;
 import static plannery.flora.enums.ResponseMessage.SUCCESS_DIARY_DELETE;
 import static plannery.flora.enums.ResponseMessage.SUCCESS_DIARY_UPDATE;
 
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -43,7 +44,7 @@ public class DiaryController {
   @PostMapping("/diary")
   public ResponseEntity<String> createDiary(@AuthenticationPrincipal UserDetails userDetails,
       @RequestParam("file") MultipartFile file, @PathVariable Long memberId,
-      @RequestPart DiaryCreateDto diaryCreateDto) {
+      @RequestPart @Valid DiaryCreateDto diaryCreateDto) {
     diaryService.createDiary(userDetails, memberId, file, diaryCreateDto);
 
     return ResponseEntity.ok(SUCCESS_DIARY_CREATE.getMessage());

--- a/src/main/java/plannery/flora/controller/EventController.java
+++ b/src/main/java/plannery/flora/controller/EventController.java
@@ -1,0 +1,145 @@
+package plannery.flora.controller;
+
+import static plannery.flora.enums.ResponseMessage.SUCCESS_EVENT_CREATE;
+import static plannery.flora.enums.ResponseMessage.SUCCESS_EVENT_DELETE;
+import static plannery.flora.enums.ResponseMessage.SUCCESS_EVENT_UPDATE;
+
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import plannery.flora.dto.event.DDayDto;
+import plannery.flora.dto.event.EventCreateDto;
+import plannery.flora.dto.event.EventListByDateDto;
+import plannery.flora.dto.event.EventListByMonthDto;
+import plannery.flora.service.EventService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/{memberId}/events")
+public class EventController {
+
+  private final EventService eventService;
+
+  /**
+   * 이벤트 생성 : 종료일시는 시작일시보다 앞설 수 없음
+   *
+   * @param userDetails    사용자 정보
+   * @param memberId       회원ID
+   * @param eventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
+   * @return
+   */
+  @PostMapping
+  public ResponseEntity<String> createEvent(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @RequestBody @Valid EventCreateDto eventCreateDto) {
+    eventService.createEvent(userDetails, memberId, eventCreateDto);
+
+    return ResponseEntity.ok(SUCCESS_EVENT_CREATE.getMessage());
+  }
+
+  /**
+   * 이벤트 개별 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param eventId     이벤트ID
+   * @return EventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
+   */
+  @GetMapping("/{eventId}")
+  public ResponseEntity<EventCreateDto> getEvent(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @PathVariable Long eventId) {
+    return ResponseEntity.ok(eventService.getEvent(userDetails, memberId, eventId));
+  }
+
+  /**
+   * 오늘의 이벤트 전체 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param date        오늘 날짜
+   * @return List<EventListDto> : 이벤트ID, 제목, 시작시간, 종료시간, 인덱스
+   */
+  @GetMapping
+  public ResponseEntity<List<EventListByDateDto>> getEventsByDate(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId,
+      @RequestParam("date") @DateTimeFormat(iso = ISO.DATE) LocalDate date) {
+    return ResponseEntity.ok(eventService.getEventsByDate(userDetails, memberId, date));
+  }
+
+  /**
+   * 월별 이벤트 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param yearMonth   연월  e.g. "2024-09"
+   * @return List<EventListByMonthDto> : 이벤트ID, 제목, 시작날짜, 종료날짜, 인덱스
+   */
+  @GetMapping("/month")
+  public ResponseEntity<List<EventListByMonthDto>> getEventsByMonth(
+      @AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @RequestParam("yearMonth") String yearMonth) {
+    return ResponseEntity.ok(eventService.getEventsByMonth(userDetails, memberId, yearMonth));
+  }
+
+  /**
+   * 디데이 목록 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return List<DDayDto> : 이벤트ID, 제목, 시작날짜, 남은 날
+   */
+  @GetMapping("/dday")
+  public ResponseEntity<List<DDayDto>> getDDayList(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId) {
+    return ResponseEntity.ok(eventService.getDDayList(userDetails, memberId));
+  }
+
+  /**
+   * 이벤트 수정 : 종료일시는 시작일시보다 앞설 수 없음
+   *
+   * @param userDetails    사용자 정보
+   * @param memberId       회원ID
+   * @param eventId        이벤트ID
+   * @param eventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설졍 여부
+   * @return "이벤트 수정 완료"
+   */
+  @PutMapping("/{eventId}")
+  public ResponseEntity<String> updateEvent(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @PathVariable Long eventId,
+      @RequestBody @Valid EventCreateDto eventCreateDto) {
+    eventService.updateEvent(userDetails, memberId, eventId, eventCreateDto);
+
+    return ResponseEntity.ok(SUCCESS_EVENT_UPDATE.getMessage());
+  }
+
+  /**
+   * 이벤트 삭제
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param eventId     이벤트ID
+   * @return "이벤트 삭제 완료"
+   */
+  @DeleteMapping("/{eventId}")
+  public ResponseEntity<String> deleteEvent(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @PathVariable Long eventId) {
+    eventService.deleteEvent(userDetails, memberId, eventId);
+
+    return ResponseEntity.ok(SUCCESS_EVENT_DELETE.getMessage());
+  }
+}

--- a/src/main/java/plannery/flora/controller/MemberController.java
+++ b/src/main/java/plannery/flora/controller/MemberController.java
@@ -6,6 +6,7 @@ import static plannery.flora.enums.ResponseMessage.SUCCESS_SEND_PASSWORD_CHANGE;
 import static plannery.flora.enums.ResponseMessage.SUCCESS_SIGNOUT;
 import static plannery.flora.enums.ResponseMessage.SUCCESS_SIGNUP;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +23,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import plannery.flora.dto.member.ChangePasswordDto;
 import plannery.flora.dto.member.MemberInfoDto;
+import plannery.flora.dto.member.PasswordChangeDto;
 import plannery.flora.dto.member.SignUpDto;
 import plannery.flora.service.MemberService;
 
@@ -41,7 +42,7 @@ public class MemberController {
    * @return JWT 토큰 & "회원가입 완료"
    */
   @PostMapping("/signup")
-  public ResponseEntity<String> signUp(@RequestBody @Validated SignUpDto signUpDto) {
+  public ResponseEntity<String> signUp(@RequestBody @Valid SignUpDto signUpDto) {
     String token = memberService.signUpOrSignIn(signUpDto.getEmail(), signUpDto.getPassword());
 
     HttpHeaders httpHeaders = new HttpHeaders();
@@ -83,13 +84,13 @@ public class MemberController {
    *
    * @param token             JWT 토큰
    * @param memberId          회원ID
-   * @param changePasswordDto 현재 비밀번호, 새 비밀번호
+   * @param passwordChangeDto 현재 비밀번호, 새 비밀번호
    * @return "비밀번호 변경 완료"
    */
   @PutMapping("/{memberId}/password")
   public ResponseEntity<String> changePassword(@RequestParam String token,
-      @PathVariable Long memberId, @RequestBody @Validated ChangePasswordDto changePasswordDto) {
-    memberService.changePassword(token, memberId, changePasswordDto);
+      @PathVariable Long memberId, @RequestBody @Validated PasswordChangeDto passwordChangeDto) {
+    memberService.changePassword(token, memberId, passwordChangeDto);
 
     return ResponseEntity.ok(SUCCESS_PASSWORD_CHANGE.getMessage());
   }

--- a/src/main/java/plannery/flora/dto/event/DDayDto.java
+++ b/src/main/java/plannery/flora/dto/event/DDayDto.java
@@ -1,0 +1,22 @@
+package plannery.flora.dto.event;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DDayDto {
+
+  private Long eventId;
+
+  private String title;
+
+  private LocalDate startDate;
+
+  private int remain;
+}

--- a/src/main/java/plannery/flora/dto/event/EventCreateDto.java
+++ b/src/main/java/plannery/flora/dto/event/EventCreateDto.java
@@ -1,0 +1,35 @@
+package plannery.flora.dto.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventCreateDto {
+
+  @NotBlank(message = "제목은 빈 값일 수 없습니다.")
+  private String title;
+
+  private String description;
+
+  @NotNull(message = "시작일시는 빈 값일 수 없습니다.")
+  private LocalDateTime startDateTime;
+
+  @NotNull(message = "종료일시는 빈 값일 수 없습니다.")
+  private LocalDateTime endDateTime;
+
+  @NotNull(message = "인덱스 색상 코드는 빈 값일 수 없습니다.")
+  private String indexColor;
+
+  @JsonProperty("isDDay")
+  @NotNull(message = "디데이 설정 여부는 빈 값일 수 없습니다.")
+  private boolean isDDay;
+}

--- a/src/main/java/plannery/flora/dto/event/EventListByDateDto.java
+++ b/src/main/java/plannery/flora/dto/event/EventListByDateDto.java
@@ -1,0 +1,24 @@
+package plannery.flora.dto.event;
+
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventListByDateDto {
+
+  private Long eventId;
+
+  private String title;
+
+  private LocalTime startTime;
+
+  private LocalTime endTime;
+
+  private String indexColor;
+}

--- a/src/main/java/plannery/flora/dto/event/EventListByMonthDto.java
+++ b/src/main/java/plannery/flora/dto/event/EventListByMonthDto.java
@@ -1,0 +1,24 @@
+package plannery.flora.dto.event;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventListByMonthDto {
+
+  private Long eventId;
+
+  private String title;
+
+  private LocalDate startDate;
+
+  private LocalDate endDate;
+
+  private String indexColor;
+}

--- a/src/main/java/plannery/flora/dto/member/PasswordChangeDto.java
+++ b/src/main/java/plannery/flora/dto/member/PasswordChangeDto.java
@@ -11,14 +11,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChangePasswordDto {
+public class PasswordChangeDto {
 
   @NotBlank(message = "현재 비밀번호는 필수 입력값입니다.")
   private String oldPassword;
 
   @NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
   @Pattern(
-      regexp = "^(?=^.{8,16}$)(?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()_+}{\":;'?/<>.,])(?!.*\\s).*$",
-      message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+      regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|])[A-Za-z\\d~!@#$%^&*()+|]{8,16}$",
+      message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 각각 하나씩 포함해야 합니다."
+  )
   private String newPassword;
 }

--- a/src/main/java/plannery/flora/dto/member/SignUpDto.java
+++ b/src/main/java/plannery/flora/dto/member/SignUpDto.java
@@ -19,6 +19,9 @@ public class SignUpDto {
   private String email;
 
   @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-  @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
+  @Pattern(
+      regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|])[A-Za-z\\d~!@#$%^&*()+|]{8,16}$",
+      message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 각각 하나씩 포함해야 합니다."
+  )
   private String password;
 }

--- a/src/main/java/plannery/flora/entity/EventEntity.java
+++ b/src/main/java/plannery/flora/entity/EventEntity.java
@@ -1,0 +1,60 @@
+package plannery.flora.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "event")
+public class EventEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @Column(nullable = false)
+  private LocalDateTime startDateTime;
+
+  @Column(nullable = false)
+  private LocalDateTime endDateTime;
+
+  @Column(nullable = false)
+  private String indexColor;
+
+  @Column(nullable = false)
+  private boolean isDDay;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity member;
+
+  public void updateEvent(String newTitle, String newDescription, LocalDateTime newStartDateTime,
+      LocalDateTime newEndDateTime, String newIndexColor, boolean newDDay) {
+    this.title = newTitle;
+    this.description = newDescription;
+    this.startDateTime = newStartDateTime;
+    this.endDateTime = newEndDateTime;
+    this.indexColor = newIndexColor;
+    this.isDDay = newDDay;
+  }
+}

--- a/src/main/java/plannery/flora/entity/MemberEntity.java
+++ b/src/main/java/plannery/flora/entity/MemberEntity.java
@@ -48,6 +48,12 @@ public class MemberEntity extends BaseEntity {
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<DiaryEntity> diaries;
 
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<NotificationListEntity> notifications;
+
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<EventEntity> events;
+
   public void updatePassword(String newPassword) {
     this.password = newPassword;
   }

--- a/src/main/java/plannery/flora/enums/ResponseMessage.java
+++ b/src/main/java/plannery/flora/enums/ResponseMessage.java
@@ -18,7 +18,11 @@ public enum ResponseMessage {
   SUCCESS_PROMISE_DELETE("다짐 삭제 완료"),
   SUCCESS_DIARY_CREATE("일기 생성 완료"),
   SUCCESS_DIARY_UPDATE("일기 수정 완료"),
-  SUCCESS_DIARY_DELETE("일기 삭제 완료");
+  SUCCESS_DIARY_DELETE("일기 삭제 완료"),
+  SUCCESS_NOTIFICATION_CREATE("알림 생성 완료"),
+  SUCCESS_EVENT_CREATE("이벤트 생성 완료"),
+  SUCCESS_EVENT_UPDATE("이벤트 수정 완료"),
+  SUCCESS_EVENT_DELETE("이벤트 삭제 완료");
 
   private final String message;
 }

--- a/src/main/java/plannery/flora/exception/ErrorCode.java
+++ b/src/main/java/plannery/flora/exception/ErrorCode.java
@@ -24,7 +24,9 @@ public enum ErrorCode {
   PROMISE_NOT_FOUND(404, "다짐 내용이 존재하지 않습니다."),
   PROMISE_EXISTS(400, "다짐이 이미 존재합니다."),
   DIARY_NOT_FOUND(404, "해당 일기가 존재하지 않습니다."),
-  DIARY_EXISTS(400, "해당 날짜에 일기가 이미 존재합니다.");
+  DIARY_EXISTS(400, "해당 날짜에 일기가 이미 존재합니다."),
+  EVENT_NOT_FOUND(404, "해당 이벤트가 존재하지 않습니다."),
+  INVALID_DATETIME(400, "종료일시는 시작일시보다 앞설 수 없습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plannery/flora/repository/EventRepository.java
+++ b/src/main/java/plannery/flora/repository/EventRepository.java
@@ -1,0 +1,26 @@
+package plannery.flora.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import plannery.flora.entity.EventEntity;
+
+@Repository
+public interface EventRepository extends JpaRepository<EventEntity, Long> {
+
+  List<EventEntity> findAllByMemberIdAndStartDateTimeLessThanEqualAndEndDateTimeGreaterThanEqual(
+      Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay);
+
+  @Query("SELECT e FROM EventEntity e WHERE e.member.id = :memberId " +
+      "AND (e.startDateTime <= :endDate AND e.endDateTime >= :startDate)")
+  List<EventEntity> findEventsForMemberWithinMonth(@Param("memberId") Long memberId,
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+
+  @Query("SELECT e FROM EventEntity e WHERE e.member.id = :memberId AND e.isDDay = true AND e.startDateTime >= :todayStartOfDay")
+  List<EventEntity> findDDayEventsByMemberId(@Param("memberId") Long memberId,
+      @Param("todayStartOfDay") LocalDateTime todayStartOfDay);
+}

--- a/src/main/java/plannery/flora/service/EventService.java
+++ b/src/main/java/plannery/flora/service/EventService.java
@@ -1,0 +1,208 @@
+package plannery.flora.service;
+
+import static plannery.flora.exception.ErrorCode.EVENT_NOT_FOUND;
+import static plannery.flora.exception.ErrorCode.INVALID_DATETIME;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plannery.flora.component.SecurityUtils;
+import plannery.flora.dto.event.DDayDto;
+import plannery.flora.dto.event.EventCreateDto;
+import plannery.flora.dto.event.EventListByDateDto;
+import plannery.flora.dto.event.EventListByMonthDto;
+import plannery.flora.entity.EventEntity;
+import plannery.flora.entity.MemberEntity;
+import plannery.flora.exception.CustomException;
+import plannery.flora.repository.EventRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EventService {
+
+  private final SecurityUtils securityUtils;
+  private final EventRepository eventRepository;
+
+  /**
+   * 이벤트 생성 : 종료일시는 시작일시보다 앞설 수 없음
+   *
+   * @param userDetails    사용자 정보
+   * @param memberId       회원ID
+   * @param eventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
+   */
+  public void createEvent(UserDetails userDetails, Long memberId, EventCreateDto eventCreateDto) {
+    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
+
+    if (eventCreateDto.getStartDateTime().isAfter(eventCreateDto.getEndDateTime())) {
+      throw new CustomException(INVALID_DATETIME);
+    }
+
+    EventEntity event = EventEntity.builder()
+        .title(eventCreateDto.getTitle())
+        .description(eventCreateDto.getDescription())
+        .startDateTime(eventCreateDto.getStartDateTime())
+        .endDateTime(eventCreateDto.getEndDateTime())
+        .indexColor(eventCreateDto.getIndexColor())
+        .isDDay(eventCreateDto.isDDay())
+        .member((member))
+        .build();
+
+    eventRepository.save(event);
+  }
+
+  /**
+   * 이벤트 개별 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param eventId     이벤트ID
+   * @return EventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
+   */
+  public EventCreateDto getEvent(UserDetails userDetails, Long memberId, Long eventId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    EventEntity event = eventRepository.findById(eventId)
+        .orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
+
+    return EventCreateDto.builder()
+        .title(event.getTitle())
+        .description(event.getDescription())
+        .startDateTime(event.getStartDateTime())
+        .endDateTime(event.getEndDateTime())
+        .indexColor(event.getIndexColor())
+        .isDDay(event.isDDay())
+        .build();
+  }
+
+  /**
+   * 오늘의 이벤트 전체 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param date        오늘 날짜
+   * @return List<EventListDto> : 이벤트ID, 제목, 시작시간, 종료시간, 인덱스
+   */
+  public List<EventListByDateDto> getEventsByDate(UserDetails userDetails, Long memberId,
+      LocalDate date) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    List<EventEntity> eventList = eventRepository.findAllByMemberIdAndStartDateTimeLessThanEqualAndEndDateTimeGreaterThanEqual(
+        memberId, date.atStartOfDay(), date.atTime(23, 59, 59));
+
+    return eventList.stream()
+        .map(event -> EventListByDateDto.builder()
+            .eventId(event.getId())
+            .title(event.getTitle())
+            .startTime(event.getStartDateTime().toLocalTime())
+            .endTime(event.getEndDateTime().toLocalTime())
+            .indexColor(event.getIndexColor()).build())
+        .toList();
+  }
+
+  /**
+   * 월별 이벤트 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param yearMonth   연월 e.g. "2024-09"
+   * @return List<EventListByMonthDto> : 이벤트ID, 제목, 시작날짜, 종료날짜, 인덱스
+   */
+  public List<EventListByMonthDto> getEventsByMonth(UserDetails userDetails, Long memberId,
+      String yearMonth) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    YearMonth parsedYearMonth = YearMonth.parse(yearMonth, DateTimeFormatter.ofPattern("yyyy-MM"));
+    LocalDate startDate = parsedYearMonth.atDay(1);
+    LocalDate endDate = parsedYearMonth.atEndOfMonth().plusDays(1);
+
+    LocalDateTime startDateTime = startDate.atStartOfDay();
+    LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
+
+    List<EventEntity> eventList = eventRepository.findEventsForMemberWithinMonth(memberId,
+        startDateTime, endDateTime);
+
+    return eventList.stream()
+        .map(event -> EventListByMonthDto.builder()
+            .eventId(event.getId())
+            .title(event.getTitle())
+            .startDate(event.getStartDateTime().toLocalDate())
+            .endDate(event.getEndDateTime().toLocalDate())
+            .indexColor(event.getIndexColor()).build())
+        .toList();
+  }
+
+  /**
+   * 디데이 목록 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return List<DDayDto> : 이벤트ID, 제목, 시작날짜, 남은 날
+   */
+  public List<DDayDto> getDDayList(UserDetails userDetails, Long memberId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    List<EventEntity> dDayList = eventRepository.findDDayEventsByMemberId(memberId,
+        LocalDate.now().atStartOfDay());
+
+    return dDayList.stream()
+        .map(dDay -> DDayDto.builder()
+            .eventId(dDay.getId())
+            .title(dDay.getTitle())
+            .startDate(dDay.getStartDateTime().toLocalDate())
+            .remain(
+                Period.between(LocalDate.now(), dDay.getStartDateTime().toLocalDate()).getDays())
+            .build())
+        .sorted(Comparator.comparingInt(DDayDto::getRemain))
+        .toList();
+  }
+
+  /**
+   * 이벤트 수정 : 종료일시는 시작일시보다 앞설 수 없음
+   *
+   * @param userDetails    사용자 정보
+   * @param memberId       회원ID
+   * @param eventId        이벤트 ID
+   * @param eventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
+   */
+  public void updateEvent(UserDetails userDetails, Long memberId, Long eventId,
+      EventCreateDto eventCreateDto) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    if (eventCreateDto.getStartDateTime().isAfter(eventCreateDto.getEndDateTime())) {
+      throw new CustomException(INVALID_DATETIME);
+    }
+
+    EventEntity event = eventRepository.findById(eventId)
+        .orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
+
+    event.updateEvent(eventCreateDto.getTitle(), eventCreateDto.getDescription(),
+        eventCreateDto.getStartDateTime(), eventCreateDto.getEndDateTime(),
+        eventCreateDto.getIndexColor(), eventCreateDto.isDDay());
+  }
+
+  /**
+   * 이벤트 삭제
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param eventId     이벤트ID
+   */
+  public void deleteEvent(UserDetails userDetails, Long memberId, Long eventId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    EventEntity event = eventRepository.findById(eventId)
+        .orElseThrow(() -> new CustomException(EVENT_NOT_FOUND));
+
+    eventRepository.delete(event);
+  }
+}


### PR DESCRIPTION
# 변경사항
### AS-IS
- **`@Valid`가 제대로 작동하지 않는 오류**

- **회원 탈퇴 시 S3 bucket에 해당 회원이 업로드한 이미지가 남아 있음**

- **잘못된 비밀번호 정규식**
  - 의도 : 영문 대문자 1자, 영문 소문자 1자, 숫자 1자, 특수문자 1자를 포함한 8~16자리의 비밀번호
  - 잘못된 정규식 : 영문 대소문자 1자(대소문자 구분 없음), 숫자 1자, 특수문자 1자(보안 상 사용을 지양해야 할 특수문자 포함)를 포함한 8~16자리의 비밀번호

- **이벤트 관련 기능 부재**

<br><br>

### TO-BE
**`@Validated`가 제대로 작동하도록 수정**
- **build.gradle** : spring-validation 추가
- **DiaryController** : `@Validated` -> `@Valid`로 변경
- **MemberController** : `@Validated` -> `@Valid`로 변경

<br>

**회원 탈퇴 시 S3 bucket에 해당 회원이 업로드한 이미지를 삭제하도록 하는 기능 추가**
- **S3ImageUpload**
  - **deleteAllImages()** : 회원과 관련된 S3 이미지 전체 삭제 기능
- **MemberService**
  - **deleteMember()** : 회원과 관련된 S3 이미지 전체 삭제 기능 추가

<br>

**비밀번호 정규식 수정**
- 영문 대문자 1자, 영문 소문자 1자, 숫자 1자, 특수문자 1자를 포함한 8~16자리의 비밀번호
**`^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|])[A-Za-z\\d~!@#$%^&*()+|]{8,16}$`**

<br>

**이벤트 기능 구현**
- **EventController & EventService**
  - **createEvent()**
    - 본인 확인 후 이벤트 생성
    - 종료일시는 시작일시보다 앞설 수 없음
    - EventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
  - **getEvent()**
    - 본인 확인 후 이벤트 개별 조회
    - return EventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
  - **getEventsByDate()**
    - 본인 확인 후 오늘의 이벤트 전체 조회
    - param : date(오늘 날짜)
    - return List<EventListDto> : 이벤트ID, 제목, 시작시간, 종료시간, 인덱스
  - **getEventsByMonth()**
    - 본인 확인 후 월별 이벤트 조회
    - param : yearMonth(연월, e.g. 2024-09)
    - return List<EventListByMonthDto> : 이벤트ID, 제목, 시작날짜, 종료날짜, 인덱스
  - **getDDayList()**
    - 본인 확인 후 디데이 목록 조회
    - return List<DDayDto> : 이벤트ID, 제목, 시작날짜, 남은 날(d-day)
  - **updateEvent()**
    - 본인 확인 후 이벤트 수정
    - 종료일시는 시작일시보다 앞설 수 없음
    - EventCreateDto : 제목, 설명, 시작일시, 종료일시, 인덱스, 디데이 설정 여부
  - **deleteEvent()**
    - 본인 확인 후 이벤트 삭제

<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드