### PR TITLE
플로라 기능 구현

### DIFF
--- a/src/main/java/plannery/flora/controller/FloraController.java
+++ b/src/main/java/plannery/flora/controller/FloraController.java
@@ -1,0 +1,33 @@
+package plannery.flora.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plannery.flora.dto.flora.FloraDto;
+import plannery.flora.service.FloraService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members/{memberId}/flora")
+public class FloraController {
+
+  private final FloraService floraService;
+
+  /**
+   * 플로라 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return FloraDto : 카운트, 플로라 타입
+   */
+  @GetMapping
+  public ResponseEntity<FloraDto> getFlora(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId) {
+    return ResponseEntity.ok(floraService.getFlora(userDetails, memberId));
+  }
+}

--- a/src/main/java/plannery/flora/dto/flora/FloraDto.java
+++ b/src/main/java/plannery/flora/dto/flora/FloraDto.java
@@ -1,0 +1,18 @@
+package plannery.flora.dto.flora;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plannery.flora.enums.FloraType;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FloraDto {
+
+  private int count;
+
+  private FloraType floraType;
+}

--- a/src/main/java/plannery/flora/entity/FloraEntity.java
+++ b/src/main/java/plannery/flora/entity/FloraEntity.java
@@ -1,0 +1,46 @@
+package plannery.flora.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plannery.flora.enums.FloraType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "flora")
+public class FloraEntity extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private int count;
+
+  @Enumerated(EnumType.STRING)
+  private FloraType floraType;
+
+  @ManyToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private MemberEntity member;
+
+  public void updateCount(int newCount) {
+    this.count = newCount;
+  }
+
+  public void updateFloraType(FloraType newFloraType) {
+    this.floraType = newFloraType;
+  }
+}

--- a/src/main/java/plannery/flora/entity/MemberEntity.java
+++ b/src/main/java/plannery/flora/entity/MemberEntity.java
@@ -54,6 +54,9 @@ public class MemberEntity extends BaseEntity {
   @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<EventEntity> events;
 
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<FloraEntity> floras;
+
   public void updatePassword(String newPassword) {
     this.password = newPassword;
   }

--- a/src/main/java/plannery/flora/enums/FloraType.java
+++ b/src/main/java/plannery/flora/enums/FloraType.java
@@ -1,0 +1,8 @@
+package plannery.flora.enums;
+
+public enum FloraType {
+  FLORA_1,
+  FLORA_2,
+  FLORA_3,
+  FLORA_4
+}

--- a/src/main/java/plannery/flora/exception/ErrorCode.java
+++ b/src/main/java/plannery/flora/exception/ErrorCode.java
@@ -26,7 +26,9 @@ public enum ErrorCode {
   DIARY_NOT_FOUND(404, "해당 일기가 존재하지 않습니다."),
   DIARY_EXISTS(400, "해당 날짜에 일기가 이미 존재합니다."),
   EVENT_NOT_FOUND(404, "해당 이벤트가 존재하지 않습니다."),
-  INVALID_DATETIME(400, "종료일시는 시작일시보다 앞설 수 없습니다.");
+  INVALID_DATETIME(400, "종료일시는 시작일시보다 앞설 수 없습니다."),
+  FLORA_NOT_FOUND(404, "해당 회원의 플로라를 찾을 수 없습니다."),
+  FLORA_EXISTS(400, "플로라가 이미 존재합니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/plannery/flora/repository/FloraRepository.java
+++ b/src/main/java/plannery/flora/repository/FloraRepository.java
@@ -1,0 +1,13 @@
+package plannery.flora.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import plannery.flora.entity.FloraEntity;
+
+@Repository
+public interface FloraRepository extends JpaRepository<FloraEntity, Long> {
+
+  Optional<FloraEntity> findByMemberId(Long memberId);
+
+}

--- a/src/main/java/plannery/flora/service/FloraService.java
+++ b/src/main/java/plannery/flora/service/FloraService.java
@@ -1,0 +1,108 @@
+package plannery.flora.service;
+
+import static plannery.flora.enums.FloraType.FLORA_1;
+import static plannery.flora.exception.ErrorCode.FLORA_EXISTS;
+import static plannery.flora.exception.ErrorCode.FLORA_NOT_FOUND;
+import static plannery.flora.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plannery.flora.component.SecurityUtils;
+import plannery.flora.dto.flora.FloraDto;
+import plannery.flora.entity.FloraEntity;
+import plannery.flora.entity.MemberEntity;
+import plannery.flora.enums.FloraType;
+import plannery.flora.exception.CustomException;
+import plannery.flora.repository.FloraRepository;
+import plannery.flora.repository.MemberRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FloraService {
+
+  private final FloraRepository floraRepository;
+  private final MemberRepository memberRepository;
+  private final SecurityUtils securityUtils;
+
+  /**
+   * 회원가입 시 호출 : FloraEntity 생성
+   *
+   * @param memberId 회원ID
+   */
+  public void createMyFlora(Long memberId) {
+    if (floraRepository.findByMemberId(memberId).isPresent()) {
+      throw new CustomException(FLORA_EXISTS);
+    }
+
+    MemberEntity member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    FloraEntity flora = FloraEntity.builder()
+        .member(member)
+        .count(1)
+        .floraType(FLORA_1)
+        .build();
+
+    floraRepository.save(flora);
+  }
+
+  /**
+   * 로그인 시 FloraEntity 업데이트 : 마지막 updatedAt 날짜가 오늘이 아니라면 출석 체크
+   *
+   * @param memberId 회원ID
+   */
+  public void updateFloraOnLogin(Long memberId) {
+    FloraEntity flora = floraRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new CustomException(FLORA_NOT_FOUND));
+
+    LocalDate lastUpdatedDate = flora.getUpdatedAt().toLocalDate();
+    LocalDate today = LocalDate.now();
+
+    if (!lastUpdatedDate.equals(today)) {
+      flora.updateCount(flora.getCount() + 1);
+      updateFloraType(flora);
+    }
+  }
+
+  /**
+   * FloraEntity 업데이트 로직
+   *
+   * @param flora
+   */
+  private void updateFloraType(FloraEntity flora) {
+    int count = flora.getCount();
+
+    if (count >= 90 && flora.getFloraType() != FloraType.FLORA_4) {
+      flora.updateFloraType(FloraType.FLORA_4);
+    } else if (count >= 40 && flora.getFloraType() != FloraType.FLORA_3) {
+      flora.updateFloraType(FloraType.FLORA_3);
+    } else if (count >= 10 && flora.getFloraType() != FloraType.FLORA_2) {
+      flora.updateFloraType(FloraType.FLORA_2);
+    } else if (flora.getFloraType() != FloraType.FLORA_1) {
+      flora.updateFloraType(FloraType.FLORA_1);
+    }
+  }
+
+  /**
+   * 플로롸 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @return FloraDto : 카운트, 플로라 타입
+   */
+  public FloraDto getFlora(UserDetails userDetails, Long memberId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    FloraEntity flora = floraRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new CustomException(FLORA_NOT_FOUND));
+
+    return FloraDto.builder()
+        .count(flora.getCount())
+        .floraType(flora.getFloraType())
+        .build();
+  }
+}

--- a/src/main/java/plannery/flora/service/MemberService.java
+++ b/src/main/java/plannery/flora/service/MemberService.java
@@ -37,6 +37,7 @@ public class MemberService {
   private final S3ImageUpload s3ImageUpload;
   private final ImageService imageService;
   private final EmailService emailService;
+  private final FloraService floraService;
   private final NotificationService notificationService;
   private final BlacklistTokenService blacklistTokenService;
 
@@ -61,6 +62,9 @@ public class MemberService {
       if (passwordEncoder.matches(password, member.getPassword())) {
         // 비밀번호가 일치하는 경우 : 로그인 성공
         log.info("로그인 성공");
+
+        floraService.updateFloraOnLogin(member.getId());
+
         return jwtTokenProvider.generateToken(member.getId(), member.getEmail(),
             member.getRole());
       } else {
@@ -79,6 +83,7 @@ public class MemberService {
 
       memberRepository.save(newMember);
       imageService.createDefaultImage(newMember.getId());
+      floraService.createMyFlora(newMember.getId());
 
       return jwtTokenProvider.generateToken(newMember.getId(), newMember.getEmail(),
           newMember.getRole());


### PR DESCRIPTION
# 변경사항
### AS-IS
- **플로라 기능 부재**



<br><br>

### TO-BE
**플로라 기능 구현**
- **MemberService**
  - signUpOrSignIn()
    - 회원가입 시 FloraEntity를 생성하도록 함
    - 로그인 시 FloraEntity의 count(출석 수)를 업데이트하도록 함
- **FloraController**
  - getFlora()
    - 플로라 조회 api
    - userDetails, memberId
    - return FloraDto : 카운트(출석 수), 플로라 타입
- **FloraService**
  - createMyFlora()
    - 회원가입 시 호출
    - FloraEntity 생성 로직
  - updateFloraOnLogin()
    - 로그인 시 FloraEntity 업데이트
    - 마지막 updatedAt 날짜가 오늘이 아니라면 출석 체크
  - updateFloraType()
    - FloraEntity 업데이트 로직
  - getFlora()
    - 플로라 조회
    - userDetails, memberId
    - return FloraDto : 카운트, 플로라 타입



<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드