### PR TITLE
투두 개별 조회, 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/plannery/flora/controller/TodoController.java
+++ b/src/main/java/plannery/flora/controller/TodoController.java
@@ -2,6 +2,8 @@ package plannery.flora.controller;
 
 import static plannery.flora.enums.ResponseMessage.SUCCESS_TODO_COMPLETE;
 import static plannery.flora.enums.ResponseMessage.SUCCESS_TODO_CREATE;
+import static plannery.flora.enums.ResponseMessage.SUCCESS_TODO_DELETE;
+import static plannery.flora.enums.ResponseMessage.SUCCESS_TODO_UPDATE;
 
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import plannery.flora.dto.todo.TodoCheckDto;
 import plannery.flora.dto.todo.TodoCreateDto;
 import plannery.flora.dto.todo.TodoResponseDto;
 import plannery.flora.enums.TodoType;
@@ -68,64 +72,65 @@ public class TodoController {
   /**
    * 투두 완료 체크
    *
-   * @param userDetails 사용자 정보
-   * @param memberId    회원ID
-   * @param todoIds     투두ID 목록
+   * @param userDetails   사용자 정보
+   * @param memberId      회원ID
+   * @param todoCheckDtos 투두ID, 완료 여부 목록
    * @return "투두 완료 체크 성공"
    */
   @PutMapping("/complete")
   public ResponseEntity<String> completeTodos(@AuthenticationPrincipal UserDetails userDetails,
-      @PathVariable Long memberId, @RequestBody List<Long> todoIds) {
-    todoService.completeTodos(userDetails, memberId, todoIds);
+      @PathVariable Long memberId, @RequestBody @Valid List<TodoCheckDto> todoCheckDtos) {
+    todoService.completeTodos(userDetails, memberId, todoCheckDtos);
 
     return ResponseEntity.ok(SUCCESS_TODO_COMPLETE.getMessage());
   }
 
-//  /**
-//   * 투두 개별 조회
-//   *
-//   * @param userDetails 사용자 정보
-//   * @param memberId    회원ID
-//   * @param todoId      투두ID
-//   * @return todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
-//   */
-//  @GetMapping("/{todoId}")
-//  public ResponseEntity<TodoCreateDto> getTodo(@AuthenticationPrincipal UserDetails userDetails,
-//      @PathVariable Long memberId, @PathVariable Long todoId) {
-//    return ResponseEntity.ok(todoService.getTodo(userDetails, memberId, todoId));
-//  }
-//
-//  /**
-//   * 투두 수정
-//   *
-//   * @param userDetails   사용자 정보
-//   * @param memberId      회원ID
-//   * @param todoId        투두ID
-//   * @param todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
-//   * @return "투두 수정 완료"
-//   */
-//  @PutMapping("/{todoId}")
-//  public ResponseEntity<String> changeTodo(@AuthenticationPrincipal UserDetails userDetails,
-//      @PathVariable Long memberId, @PathVariable Long todoId,
-//      @RequestBody @Valid TodoCreateDto todoCreateDto) {
-//    todoService.changeTodo(userDetails, memberId, todoId, todoCreateDto);
-//
-//    return ResponseEntity.ok(SUCCESS_TODO_UPDATE.getMessage());
-//  }
-//
-//  /**
-//   * 투두 삭제
-//   *
-//   * @param userDetails 사용자 정보
-//   * @param memberId    회원ID
-//   * @param todoId      투두ID
-//   * @return "투두 삭제 완료"
-//   */
-//  @DeleteMapping("/{todoId}")
-//  public ResponseEntity<String> deleteTodo(@AuthenticationPrincipal UserDetails userDetails,
-//      @PathVariable Long memberId, @PathVariable Long todoId) {
-//    todoService.deleteTodo(userDetails, memberId, todoId);
-//
-//    return ResponseEntity.ok(SUCCESS_TODO_DELETE.getMessage());
-//  }
+  /**
+   * 투두 개별 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param todoId      투두ID
+   * @return todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
+   */
+  @GetMapping("/{todoId}")
+  public ResponseEntity<TodoCreateDto> getTodo(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @PathVariable Long todoId) {
+    return ResponseEntity.ok(todoService.getTodo(userDetails, memberId, todoId));
+  }
+
+  /**
+   * 투두 수정
+   *
+   * @param userDetails   사용자 정보
+   * @param memberId      회원ID
+   * @param todoId        투두ID
+   * @param todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
+   * @return "투두 수정 완료"
+   */
+  @PutMapping("/{todoId}")
+  public ResponseEntity<String> changeTodo(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @PathVariable Long todoId,
+      @RequestBody @Valid TodoCreateDto todoCreateDto) {
+    todoService.changeTodo(userDetails, memberId, todoId, todoCreateDto);
+
+    return ResponseEntity.ok(SUCCESS_TODO_UPDATE.getMessage());
+  }
+
+  /**
+   * 투두 삭제
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param todoId      투두ID
+   * @param isDeleteAll 전체 삭제 여부
+   * @return "투두 삭제 완료"
+   */
+  @DeleteMapping("/{todoId}")
+  public ResponseEntity<String> deleteTodo(@AuthenticationPrincipal UserDetails userDetails,
+      @PathVariable Long memberId, @PathVariable Long todoId, @RequestParam boolean isDeleteAll) {
+    todoService.deleteTodo(userDetails, memberId, todoId, isDeleteAll);
+
+    return ResponseEntity.ok(SUCCESS_TODO_DELETE.getMessage());
+  }
 }

--- a/src/main/java/plannery/flora/dto/todo/TodoCheckDto.java
+++ b/src/main/java/plannery/flora/dto/todo/TodoCheckDto.java
@@ -1,0 +1,19 @@
+package plannery.flora.dto.todo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TodoCheckDto {
+
+  private Long todoId;
+
+  @JsonProperty("isCompleted")
+  private boolean isCompleted;
+}

--- a/src/main/java/plannery/flora/entity/TodoEntity.java
+++ b/src/main/java/plannery/flora/entity/TodoEntity.java
@@ -61,6 +61,10 @@ public class TodoEntity extends BaseEntity {
     this.isCompleted = newIsCompleted;
   }
 
+  public void updateTodoRepeat(TodoRepeatEntity todoRepeatEntity) {
+    this.todoRepeat = todoRepeatEntity;
+  }
+
   public void updateTodo(String newTitle, TodoType newTodoType, String newIndexColor,
       LocalDate newTodoDate, String newDescription) {
     this.title = newTitle;

--- a/src/main/java/plannery/flora/exception/ErrorCode.java
+++ b/src/main/java/plannery/flora/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
   FLORA_NOT_FOUND(404, "해당 회원의 플로라를 찾을 수 없습니다."),
   FLORA_EXISTS(400, "플로라가 이미 존재합니다."),
   TODO_NOT_FOUND(404, "투두 엔티티가 존재하지 않습니다."),
+  TODO_COMPLETED_CHECK_MISS(409, "투두의 완료 상태가 일치하지 않습니다."),
   TODO_REPEAT_NOT_FOUND(404, "투두 반복 엔티티가 존재하지 않습니다.");
 
   private final int status;

--- a/src/main/java/plannery/flora/service/TodoService.java
+++ b/src/main/java/plannery/flora/service/TodoService.java
@@ -1,15 +1,20 @@
 package plannery.flora.service;
 
 import static plannery.flora.exception.ErrorCode.INVALID_DATETIME;
+import static plannery.flora.exception.ErrorCode.TODO_COMPLETED_CHECK_MISS;
+import static plannery.flora.exception.ErrorCode.TODO_NOT_FOUND;
+import static plannery.flora.exception.ErrorCode.TODO_REPEAT_NOT_FOUND;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plannery.flora.component.SecurityUtils;
+import plannery.flora.dto.todo.TodoCheckDto;
 import plannery.flora.dto.todo.TodoCreateDto;
 import plannery.flora.dto.todo.TodoResponseDto;
 import plannery.flora.entity.MemberEntity;
@@ -129,176 +134,237 @@ public class TodoService {
   /**
    * 투두 완료 체크
    *
-   * @param userDetails 사용자 정보
-   * @param memberId    회원ID
-   * @param todoIds     투두ID 목록
+   * @param userDetails   사용자 정보
+   * @param memberId      회원ID
+   * @param todoCheckDtos 투두ID, 완료 여부 목록
    */
-  public void completeTodos(UserDetails userDetails, Long memberId, List<Long> todoIds) {
+  public void completeTodos(UserDetails userDetails, Long memberId,
+      List<TodoCheckDto> todoCheckDtos) {
     securityUtils.validateUserDetails(userDetails, memberId);
 
-    List<TodoEntity> todos = todoRepository.findAllById(todoIds);
+    for (TodoCheckDto todoCheckDto : todoCheckDtos) {
+      TodoEntity todoEntity = todoRepository.findById(todoCheckDto.getTodoId())
+          .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
 
-    for (TodoEntity todo : todos) {
-      todo.completeCheck(!todo.isCompleted());
+      if (todoEntity.isCompleted() != todoCheckDto.isCompleted()) {
+        throw new CustomException(TODO_COMPLETED_CHECK_MISS);
+      }
+
+      todoEntity.completeCheck(!todoCheckDto.isCompleted());
     }
-
-    todoRepository.saveAll(todos);
   }
 
-//  /**
-//   * 투두 개별 조회
-//   *
-//   * @param userDetails 사용자 정보
-//   * @param memberId    회원ID
-//   * @param todoId      투두ID
-//   * @return todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
-//   */
-//  public TodoCreateDto getTodo(UserDetails userDetails, Long memberId, Long todoId) {
-//    securityUtils.validateUserDetails(userDetails, memberId);
-//
-//    TodoEntity todoEntity = todoRepository.findById(todoId)
-//        .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
-//
-//    if (todoEntity.getTodoRepeat() != null) {
-//      TodoRepeatEntity todoRepeatEntity = todoRepeatRepository.findById(
-//              todoEntity.getTodoRepeat().getId())
-//          .orElseThrow(() -> new CustomException(TODO_REPEAT_NOT_FOUND));
-//
-//      return TodoCreateDto.builder()
-//          .title(todoEntity.getTitle())
-//          .todoType(todoEntity.getTodoType())
-//          .isRoutine(todoRepeatEntity.isRoutine())
-//          .indexColor(todoEntity.getIndexColor())
-//          .startDate(todoRepeatEntity.getStartDate())
-//          .endDate(todoRepeatEntity.getEndDate())
-//          .description(todoEntity.getDescription())
-//          .repeatDays(todoRepeatEntity.getRepeatDays())
-//          .build();
-//    } else {
-//      return TodoCreateDto.builder()
-//          .title(todoEntity.getTitle())
-//          .todoType(todoEntity.getTodoType())
-//          .isRoutine(false)
-//          .indexColor(todoEntity.getIndexColor())
-//          .startDate(todoEntity.getTodoDate())
-//          .endDate(todoEntity.getTodoDate())
-//          .description(todoEntity.getDescription())
-//          .repeatDays(Collections.emptyList())
-//          .build();
-//    }
-//  }
+  /**
+   * 투두 개별 조회
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param todoId      투두ID
+   * @return todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
+   */
+  public TodoCreateDto getTodo(UserDetails userDetails, Long memberId, Long todoId) {
+    securityUtils.validateUserDetails(userDetails, memberId);
 
-//  /**
-//   * 투두 수정
-//   *
-//   * @param userDetails   사용자 정보
-//   * @param memberId      회원ID
-//   * @param todoId        투두ID
-//   * @param todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
-//   */
-//  public void changeTodo(UserDetails userDetails, Long memberId, Long todoId,
-//      TodoCreateDto todoCreateDto) {
-//    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
-//
-//    if (todoCreateDto.getStartDate() != null && todoCreateDto.getStartDate()
-//        .isAfter(todoCreateDto.getEndDate())) {
-//      throw new CustomException(INVALID_DATETIME);
-//    }
-//
-//    TodoEntity todoEntity = todoRepository.findById(todoId)
-//        .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
-//
-//    boolean isCurrentlyRoutine = todoEntity.getTodoRepeat() != null;
-//
-//    if (todoCreateDto.isRoutine()) {
-//      if (!isCurrentlyRoutine) {
-//        // 비루틴 -> 루틴
-//        TodoRepeatEntity newTodoRepeatEntity = TodoRepeatEntity.builder()
-//            .member(todoEntity.getMember())
-//            .title(todoCreateDto.getTitle())
-//            .description(todoCreateDto.getDescription())
-//            .todoType(todoCreateDto.getTodoType())
-//            .isRoutine(todoCreateDto.isRoutine())
-//            .indexColor(todoCreateDto.getIndexColor())
-//            .startDate(todoCreateDto.getStartDate())
-//            .endDate(todoCreateDto.getEndDate())
-//            .repeatDays(todoCreateDto.getRepeatDays())
-//            .build();
-//        todoRepeatRepository.save(newTodoRepeatEntity);
-//
-//        todoRepository.deleteById(todoId);
-//
-//        LocalDate currentDate = todoCreateDto.getStartDate();
-//        LocalDate endDate = todoCreateDto.getEndDate();
-//        List<DayOfWeek> repeatDays = todoCreateDto.getRepeatDays();
-//
-//        while (!currentDate.isAfter(endDate)) {
-//          if (repeatDays.contains(currentDate.getDayOfWeek())) {
-//            TodoEntity newTodoEntity = TodoEntity.builder()
-//                .member(member)
-//                .title(todoCreateDto.getTitle())
-//                .description(todoCreateDto.getDescription())
-//                .todoType(todoCreateDto.getTodoType())
-//                .todoDate(currentDate)
-//                .indexColor(todoCreateDto.getIndexColor())
-//                .isCompleted(false)
-//                .todoRepeat(newTodoRepeatEntity)
-//                .build();
-//
-//            todoRepository.save(newTodoEntity);
-//          }
-//          currentDate = currentDate.plusDays(1);
-//        }
-//      } else {
-//        // 루틴 -> 루틴
-//        TodoRepeatEntity todoRepeatEntity = todoEntity.getTodoRepeat();
-//
-//        todoRepeatEntity.updateTodoRepeat(todoCreateDto.getTitle(), todoCreateDto.getDescription(),
-//            todoCreateDto.getTodoType(), todoCreateDto.getIndexColor(),
-//            todoCreateDto.getStartDate(), todoCreateDto.getEndDate(),
-//            todoCreateDto.getRepeatDays());
-//
-//        todoRepeatRepository.save(todoRepeatEntity);
-//
-//        List<TodoEntity> existingTodos = todoRepository.findAllByTodoRepeat(todoRepeatEntity);
-//        todoRepository.deleteAll(existingTodos);
-//
-//        LocalDate currentDate = todoCreateDto.getStartDate();
-//        LocalDate endDate = todoCreateDto.getEndDate();
-//        List<DayOfWeek> repeatDays = todoCreateDto.getRepeatDays();
-//
-//        while (!currentDate.isAfter(endDate)) {
-//          if (repeatDays.contains(currentDate.getDayOfWeek())) {
-//            TodoEntity newTodoEntity = TodoEntity.builder()
-//                .member(todoEntity.getMember())
-//                .title(todoCreateDto.getTitle())
-//                .description(todoCreateDto.getDescription())
-//                .todoType(todoCreateDto.getTodoType())
-//                .todoDate(currentDate)
-//                .indexColor(todoCreateDto.getIndexColor())
-//                .isCompleted(false) // 기본값 설정
-//                .todoRepeat(todoRepeatEntity)
-//                .build();
-//
-//            todoRepository.save(newTodoEntity);
-//          }
-//          currentDate = currentDate.plusDays(1);
-//        }
-//      }
-//    }
-//  }
-//
-//  /**
-//   * 투두 삭제
-//   *
-//   * @param userDetails 사용자 정보
-//   * @param memberId    회원ID
-//   * @param todoId      투두ID
-//   */
-//  public void deleteTodo(UserDetails userDetails, Long memberId, Long todoId) {
-//    securityUtils.validateUserDetails(userDetails, memberId);
-//
-//    todoRepository.deleteById(todoId);
-//    todoRepeatRepository.deleteAllByTodoId(todoId);
-//  }
+    TodoEntity todoEntity = todoRepository.findById(todoId)
+        .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
+
+    if (todoEntity.getTodoRepeat() != null) {
+      TodoRepeatEntity todoRepeatEntity = todoRepeatRepository.findById(
+              todoEntity.getTodoRepeat().getId())
+          .orElseThrow(() -> new CustomException(TODO_REPEAT_NOT_FOUND));
+
+      return TodoCreateDto.builder()
+          .title(todoEntity.getTitle())
+          .todoType(todoEntity.getTodoType())
+          .isRoutine(todoRepeatEntity.isRoutine())
+          .indexColor(todoEntity.getIndexColor())
+          .startDate(todoRepeatEntity.getStartDate())
+          .endDate(todoRepeatEntity.getEndDate())
+          .description(todoEntity.getDescription())
+          .repeatDays(todoRepeatEntity.getRepeatDays())
+          .build();
+    } else {
+      return TodoCreateDto.builder()
+          .title(todoEntity.getTitle())
+          .todoType(todoEntity.getTodoType())
+          .isRoutine(false)
+          .indexColor(todoEntity.getIndexColor())
+          .startDate(todoEntity.getTodoDate())
+          .endDate(todoEntity.getTodoDate())
+          .description(todoEntity.getDescription())
+          .repeatDays(Collections.emptyList())
+          .build();
+    }
+  }
+
+  /**
+   * 투두 수정
+   *
+   * @param userDetails   사용자 정보
+   * @param memberId      회원ID
+   * @param todoId        투두ID
+   * @param todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
+   */
+  public void changeTodo(UserDetails userDetails, Long memberId, Long todoId,
+      TodoCreateDto todoCreateDto) {
+    MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
+
+    if (todoCreateDto.getStartDate() != null && todoCreateDto.getStartDate()
+        .isAfter(todoCreateDto.getEndDate())) {
+      throw new CustomException(INVALID_DATETIME);
+    }
+
+    TodoEntity todoEntity = todoRepository.findById(todoId)
+        .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
+
+    boolean isCurrentlyRoutine = todoEntity.getTodoRepeat() != null;
+
+    if (todoCreateDto.isRoutine()) {
+      if (!isCurrentlyRoutine) {
+        // 비루틴 -> 루틴 : TodoRepeatEntity 생성 -> 현재 TodoEntity에 연결 -> 현재 TodoEntity를 제외한 나머지 TodoEntity 생성
+        TodoRepeatEntity newTodoRepeatEntity = TodoRepeatEntity.builder()
+            .member(todoEntity.getMember())
+            .title(todoCreateDto.getTitle())
+            .description(todoCreateDto.getDescription())
+            .todoType(todoCreateDto.getTodoType())
+            .isRoutine(todoCreateDto.isRoutine())
+            .indexColor(todoCreateDto.getIndexColor())
+            .startDate(todoCreateDto.getStartDate())
+            .endDate(todoCreateDto.getEndDate())
+            .repeatDays(todoCreateDto.getRepeatDays())
+            .build();
+        todoRepeatRepository.save(newTodoRepeatEntity);
+
+        todoEntity.updateTodoRepeat(newTodoRepeatEntity);
+        updateTodoEntity(todoEntity, todoCreateDto);
+
+        createTodosForRepeatDays(todoCreateDto, member, newTodoRepeatEntity,
+            todoEntity.getTodoDate());
+      } else {
+        // 루틴 -> 루틴 : TodoRepeatEntity 수정 -> 현재 TodoEntity는 내용 수정 -> 현재 TodoEntity의 todoDate 이후의 TodoEntity들은 전체 삭제 후 재생성
+        TodoRepeatEntity todoRepeatEntity = todoEntity.getTodoRepeat();
+
+        todoRepeatEntity.updateTodoRepeat(todoCreateDto.getTitle(), todoCreateDto.getDescription(),
+            todoCreateDto.getTodoType(), todoCreateDto.getIndexColor(),
+            todoCreateDto.getStartDate(), todoCreateDto.getEndDate(),
+            todoCreateDto.getRepeatDays());
+
+        updateTodoEntity(todoEntity, todoCreateDto);
+
+        deleteFutureTodos(todoRepeatEntity, todoEntity.getTodoDate());
+        createTodosForRepeatDays(todoCreateDto, todoEntity.getMember(), todoRepeatEntity,
+            todoEntity.getTodoDate());
+      }
+    } else {
+      if (!isCurrentlyRoutine) {
+        // 비루틴 -> 비루틴 : title, todoType, indexColor, description 수정
+        updateTodoEntity(todoEntity, todoCreateDto);
+      } else {
+        // 루틴 -> 비루틴 : TodoEntity 수정 -> 현재 TodoEntity 외의 TodoEntity들은 전부 삭제
+        TodoRepeatEntity todoRepeatEntity = todoEntity.getTodoRepeat();
+
+        updateTodoEntity(todoEntity, todoCreateDto);
+        deleteFutureTodos(todoRepeatEntity, todoEntity.getTodoDate());
+      }
+    }
+  }
+
+  /**
+   * TodoEntity 수정 : title, todoType, indexColor, todoDate, description
+   *
+   * @param todoEntity
+   * @param todoCreateDto
+   */
+  private void updateTodoEntity(TodoEntity todoEntity, TodoCreateDto todoCreateDto) {
+    todoEntity.updateTodo(todoCreateDto.getTitle(), todoCreateDto.getTodoType(),
+        todoCreateDto.getIndexColor(), todoEntity.getTodoDate(),
+        todoCreateDto.getDescription());
+  }
+
+  /**
+   * baseDate 이후의 TodoEntity 삭제
+   *
+   * @param todoRepeatEntity
+   * @param baseDate
+   */
+  private void deleteFutureTodos(TodoRepeatEntity todoRepeatEntity, LocalDate baseDate) {
+    List<TodoEntity> existingTodos = todoRepository.findAllByTodoRepeat(todoRepeatEntity);
+    List<TodoEntity> todosToDelete = existingTodos.stream()
+        .filter(todo -> todo.getTodoDate().isAfter(baseDate))
+        .toList();
+    todoRepository.deleteAll(todosToDelete);
+  }
+
+  /**
+   * TodoRepeatEntity에 따른 TodoEntity 생성 : excludedDate 제외
+   *
+   * @param todoCreateDto
+   * @param member
+   * @param todoRepeatEntity
+   * @param excludedDate
+   */
+  private void createTodosForRepeatDays(TodoCreateDto todoCreateDto, MemberEntity member,
+      TodoRepeatEntity todoRepeatEntity, LocalDate excludedDate) {
+    LocalDate currentDate = todoCreateDto.getStartDate();
+    LocalDate endDate = todoCreateDto.getEndDate();
+    List<DayOfWeek> repeatDays = todoCreateDto.getRepeatDays();
+
+    while (!currentDate.isAfter(endDate)) {
+      if (repeatDays.contains(currentDate.getDayOfWeek()) && !currentDate.equals(excludedDate)) {
+        TodoEntity newTodoEntity = TodoEntity.builder()
+            .member(member)
+            .title(todoCreateDto.getTitle())
+            .description(todoCreateDto.getDescription())
+            .todoType(todoCreateDto.getTodoType())
+            .todoDate(currentDate)
+            .indexColor(todoCreateDto.getIndexColor())
+            .isCompleted(false)
+            .todoRepeat(todoRepeatEntity)
+            .build();
+        todoRepository.save(newTodoEntity);
+      }
+      currentDate = currentDate.plusDays(1);
+    }
+  }
+
+  /**
+   * 투두 삭제
+   *
+   * @param userDetails 사용자 정보
+   * @param memberId    회원ID
+   * @param todoId      투두ID
+   * @param isDeleteAll 전체 삭제 여부
+   */
+  public void deleteTodo(UserDetails userDetails, Long memberId, Long todoId, boolean isDeleteAll) {
+    securityUtils.validateUserDetails(userDetails, memberId);
+
+    TodoEntity todoEntity = todoRepository.findById(todoId)
+        .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
+
+    boolean isCurrentlyRoutine = todoEntity.getTodoRepeat() != null;
+
+    if (isCurrentlyRoutine) {
+      if (isDeleteAll) {
+        // 루틴 : 전체 삭제
+        deleteAllRoutineTodos(todoEntity.getTodoRepeat());
+      } else {
+        // 루틴 : 개별 삭제
+        todoRepository.delete(todoEntity);
+      }
+    } else {
+      // 비루틴
+      todoRepository.delete(todoEntity);
+    }
+  }
+
+  /**
+   * 루틴 전체 삭제
+   *
+   * @param todoRepeatEntity
+   */
+  private void deleteAllRoutineTodos(TodoRepeatEntity todoRepeatEntity) {
+    List<TodoEntity> existingTodos = todoRepository.findAllByTodoRepeat(todoRepeatEntity);
+    todoRepository.deleteAll(existingTodos);
+    todoRepeatRepository.delete(todoRepeatEntity);
+  }
 }


### PR DESCRIPTION
# 변경사항
### AS-IS
- **투두 완료 체크 api : Body로 todoId의 목록을 받음**

- **투두 개별 조회, 수정, 삭제 기능 부재**


<br><br>

### TO-BE
**투두 완료 체크 api 수정**
- 기존 : Body로 todoId의 목록을 받음
- 변경 : Body로 todoId와 isCompleted(현재 완료 여부)로 이루어진 Dto의 목록을 받음

<br>

**투두 개별 조회**
- userDetails, memberId, todoId, todoCreateDto(제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일)
- 루틴 여부에 따라 로직이 나뉨
  - 루틴이라면 TodoRepeatEntity까지 조회하여 처리
  - 비루틴이라면 TodoEntity만 조회하여 처리

<br>

**투두 수정**
- userDetails, memberId, todoId, todoCreateDto(제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일)
- 4가지 경우를 나누어 처리
  - 루틴 -> 루틴
  - 루틴 -> 비루틴
  - 비루틴 -> 루틴
  - 비루틴 -> 비루틴

<br>

**투두 삭제**
- userDetails, memberId, todoId, isDeleteAll
- 전체 삭제 여부(isDeleteAll)와 루틴 여부에 따라 처



<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드