### PR TITLE
투두 기능 수정 : 투두 목록 조회 api & 투두 수정 api

### DIFF
--- a/src/main/java/plannery/flora/controller/TodoController.java
+++ b/src/main/java/plannery/flora/controller/TodoController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import plannery.flora.dto.todo.TodoCheckDto;
 import plannery.flora.dto.todo.TodoCreateDto;
 import plannery.flora.dto.todo.TodoResponseDto;
+import plannery.flora.dto.todo.TodoUpdateDto;
 import plannery.flora.enums.TodoType;
 import plannery.flora.service.TodoService;
 
@@ -105,14 +106,14 @@ public class TodoController {
    * @param userDetails   사용자 정보
    * @param memberId      회원ID
    * @param todoId        투두ID
-   * @param todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
+   * @param todoUpdateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 종료날짜, 설명, 반복 요일
    * @return "투두 수정 완료"
    */
   @PutMapping("/{todoId}")
   public ResponseEntity<String> changeTodo(@AuthenticationPrincipal UserDetails userDetails,
       @PathVariable Long memberId, @PathVariable Long todoId,
-      @RequestBody @Valid TodoCreateDto todoCreateDto) {
-    todoService.changeTodo(userDetails, memberId, todoId, todoCreateDto);
+      @RequestBody @Valid TodoUpdateDto todoUpdateDto) {
+    todoService.changeTodo(userDetails, memberId, todoId, todoUpdateDto);
 
     return ResponseEntity.ok(SUCCESS_TODO_UPDATE.getMessage());
   }

--- a/src/main/java/plannery/flora/dto/todo/TodoResponseDto.java
+++ b/src/main/java/plannery/flora/dto/todo/TodoResponseDto.java
@@ -16,6 +16,8 @@ public class TodoResponseDto {
 
   private String title;
 
+  private String indexColor;
+
   @JsonProperty("isCompleted")
   private boolean isCompleted;
 }

--- a/src/main/java/plannery/flora/dto/todo/TodoUpdateDto.java
+++ b/src/main/java/plannery/flora/dto/todo/TodoUpdateDto.java
@@ -1,0 +1,39 @@
+package plannery.flora.dto.todo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plannery.flora.enums.TodoType;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TodoUpdateDto {
+
+  @NotBlank
+  private String title;
+
+  @NotNull
+  private TodoType todoType;
+
+  @NotNull
+  @JsonProperty("isRoutine")
+  private boolean isRoutine;
+
+  @NotBlank
+  private String indexColor;
+
+  private LocalDate endDate;
+
+  private String description;
+
+  private List<DayOfWeek> repeatDays;
+}

--- a/src/main/java/plannery/flora/entity/TodoRepeatEntity.java
+++ b/src/main/java/plannery/flora/entity/TodoRepeatEntity.java
@@ -64,13 +64,12 @@ public class TodoRepeatEntity extends BaseEntity {
   private List<DayOfWeek> repeatDays;
 
   public void updateTodoRepeat(String newTitle, String newDescription, TodoType newTodoType,
-      String newIndexColor, LocalDate newStartDate, LocalDate newEndDate,
+      String newIndexColor, LocalDate newEndDate,
       List<DayOfWeek> newRepeatDays) {
     this.title = newTitle;
     this.description = newDescription;
     this.todoType = newTodoType;
     this.indexColor = newIndexColor;
-    this.startDate = newStartDate;
     this.endDate = newEndDate;
     this.repeatDays = newRepeatDays;
   }

--- a/src/main/java/plannery/flora/service/TodoService.java
+++ b/src/main/java/plannery/flora/service/TodoService.java
@@ -126,6 +126,7 @@ public class TodoService {
         .map(todo -> TodoResponseDto.builder()
             .todoId(todo.getId())
             .title(todo.getTitle())
+            .indexColor(todo.getIndexColor())
             .isCompleted(todo.isCompleted())
             .build())
         .toList();

--- a/src/main/java/plannery/flora/service/TodoService.java
+++ b/src/main/java/plannery/flora/service/TodoService.java
@@ -17,6 +17,7 @@ import plannery.flora.component.SecurityUtils;
 import plannery.flora.dto.todo.TodoCheckDto;
 import plannery.flora.dto.todo.TodoCreateDto;
 import plannery.flora.dto.todo.TodoResponseDto;
+import plannery.flora.dto.todo.TodoUpdateDto;
 import plannery.flora.entity.MemberEntity;
 import plannery.flora.entity.TodoEntity;
 import plannery.flora.entity.TodoRepeatEntity;
@@ -204,67 +205,61 @@ public class TodoService {
    * @param userDetails   사용자 정보
    * @param memberId      회원ID
    * @param todoId        투두ID
-   * @param todoCreateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 시작날짜, 종료날짜, 설명, 반복 요일
+   * @param todoUpdateDto : 제목, 투두타입(TODO_STUDY, TODO_LIFE), 루틴 여부, 인덱스 색상, 종료날짜, 설명, 반복 요일
    */
   public void changeTodo(UserDetails userDetails, Long memberId, Long todoId,
-      TodoCreateDto todoCreateDto) {
+      TodoUpdateDto todoUpdateDto) {
     MemberEntity member = securityUtils.validateUserDetails(userDetails, memberId);
-
-    if (todoCreateDto.getStartDate() != null && todoCreateDto.getStartDate()
-        .isAfter(todoCreateDto.getEndDate())) {
-      throw new CustomException(INVALID_DATETIME);
-    }
 
     TodoEntity todoEntity = todoRepository.findById(todoId)
         .orElseThrow(() -> new CustomException(TODO_NOT_FOUND));
 
     boolean isCurrentlyRoutine = todoEntity.getTodoRepeat() != null;
 
-    if (todoCreateDto.isRoutine()) {
+    if (todoUpdateDto.isRoutine()) {
       if (!isCurrentlyRoutine) {
         // 비루틴 -> 루틴 : TodoRepeatEntity 생성 -> 현재 TodoEntity에 연결 -> 현재 TodoEntity를 제외한 나머지 TodoEntity 생성
         TodoRepeatEntity newTodoRepeatEntity = TodoRepeatEntity.builder()
             .member(todoEntity.getMember())
-            .title(todoCreateDto.getTitle())
-            .description(todoCreateDto.getDescription())
-            .todoType(todoCreateDto.getTodoType())
-            .isRoutine(todoCreateDto.isRoutine())
-            .indexColor(todoCreateDto.getIndexColor())
-            .startDate(todoCreateDto.getStartDate())
-            .endDate(todoCreateDto.getEndDate())
-            .repeatDays(todoCreateDto.getRepeatDays())
+            .title(todoUpdateDto.getTitle())
+            .description(todoUpdateDto.getDescription())
+            .todoType(todoUpdateDto.getTodoType())
+            .isRoutine(todoUpdateDto.isRoutine())
+            .indexColor(todoUpdateDto.getIndexColor())
+            .startDate(todoEntity.getTodoDate())
+            .endDate(todoUpdateDto.getEndDate())
+            .repeatDays(todoUpdateDto.getRepeatDays())
             .build();
         todoRepeatRepository.save(newTodoRepeatEntity);
 
         todoEntity.updateTodoRepeat(newTodoRepeatEntity);
-        updateTodoEntity(todoEntity, todoCreateDto);
+        updateTodoEntity(todoEntity, todoUpdateDto);
 
-        createTodosForRepeatDays(todoCreateDto, member, newTodoRepeatEntity,
+        createTodosForRepeatDays(todoUpdateDto, member, newTodoRepeatEntity,
             todoEntity.getTodoDate());
       } else {
         // 루틴 -> 루틴 : TodoRepeatEntity 수정 -> 현재 TodoEntity는 내용 수정 -> 현재 TodoEntity의 todoDate 이후의 TodoEntity들은 전체 삭제 후 재생성
         TodoRepeatEntity todoRepeatEntity = todoEntity.getTodoRepeat();
 
-        todoRepeatEntity.updateTodoRepeat(todoCreateDto.getTitle(), todoCreateDto.getDescription(),
-            todoCreateDto.getTodoType(), todoCreateDto.getIndexColor(),
-            todoCreateDto.getStartDate(), todoCreateDto.getEndDate(),
-            todoCreateDto.getRepeatDays());
+        todoRepeatEntity.updateTodoRepeat(todoUpdateDto.getTitle(), todoUpdateDto.getDescription(),
+            todoUpdateDto.getTodoType(), todoUpdateDto.getIndexColor(), todoUpdateDto.getEndDate(),
+            todoUpdateDto.getRepeatDays());
 
-        updateTodoEntity(todoEntity, todoCreateDto);
+        updateTodoEntity(todoEntity, todoUpdateDto);
 
         deleteFutureTodos(todoRepeatEntity, todoEntity.getTodoDate());
-        createTodosForRepeatDays(todoCreateDto, todoEntity.getMember(), todoRepeatEntity,
+        createTodosForRepeatDays(todoUpdateDto, todoEntity.getMember(), todoRepeatEntity,
             todoEntity.getTodoDate());
       }
     } else {
       if (!isCurrentlyRoutine) {
         // 비루틴 -> 비루틴 : title, todoType, indexColor, description 수정
-        updateTodoEntity(todoEntity, todoCreateDto);
+        updateTodoEntity(todoEntity, todoUpdateDto);
       } else {
         // 루틴 -> 비루틴 : TodoEntity 수정 -> 현재 TodoEntity 외의 TodoEntity들은 전부 삭제
         TodoRepeatEntity todoRepeatEntity = todoEntity.getTodoRepeat();
 
-        updateTodoEntity(todoEntity, todoCreateDto);
+        updateTodoEntity(todoEntity, todoUpdateDto);
         deleteFutureTodos(todoRepeatEntity, todoEntity.getTodoDate());
       }
     }
@@ -274,12 +269,12 @@ public class TodoService {
    * TodoEntity 수정 : title, todoType, indexColor, todoDate, description
    *
    * @param todoEntity
-   * @param todoCreateDto
+   * @param todoUpdateDto
    */
-  private void updateTodoEntity(TodoEntity todoEntity, TodoCreateDto todoCreateDto) {
-    todoEntity.updateTodo(todoCreateDto.getTitle(), todoCreateDto.getTodoType(),
-        todoCreateDto.getIndexColor(), todoEntity.getTodoDate(),
-        todoCreateDto.getDescription());
+  private void updateTodoEntity(TodoEntity todoEntity, TodoUpdateDto todoUpdateDto) {
+    todoEntity.updateTodo(todoUpdateDto.getTitle(), todoUpdateDto.getTodoType(),
+        todoUpdateDto.getIndexColor(), todoEntity.getTodoDate(),
+        todoUpdateDto.getDescription());
   }
 
   /**
@@ -297,28 +292,28 @@ public class TodoService {
   }
 
   /**
-   * TodoRepeatEntity에 따른 TodoEntity 생성 : excludedDate 제외
+   * TodoRepeatEntity에 따른 TodoEntity 생성 : excludedDate 이후
    *
-   * @param todoCreateDto
+   * @param todoUpdateDto
    * @param member
    * @param todoRepeatEntity
    * @param excludedDate
    */
-  private void createTodosForRepeatDays(TodoCreateDto todoCreateDto, MemberEntity member,
+  private void createTodosForRepeatDays(TodoUpdateDto todoUpdateDto, MemberEntity member,
       TodoRepeatEntity todoRepeatEntity, LocalDate excludedDate) {
-    LocalDate currentDate = todoCreateDto.getStartDate();
-    LocalDate endDate = todoCreateDto.getEndDate();
-    List<DayOfWeek> repeatDays = todoCreateDto.getRepeatDays();
+    LocalDate currentDate = excludedDate;
+    LocalDate endDate = todoUpdateDto.getEndDate();
+    List<DayOfWeek> repeatDays = todoUpdateDto.getRepeatDays();
 
     while (!currentDate.isAfter(endDate)) {
       if (repeatDays.contains(currentDate.getDayOfWeek()) && !currentDate.equals(excludedDate)) {
         TodoEntity newTodoEntity = TodoEntity.builder()
             .member(member)
-            .title(todoCreateDto.getTitle())
-            .description(todoCreateDto.getDescription())
-            .todoType(todoCreateDto.getTodoType())
+            .title(todoUpdateDto.getTitle())
+            .description(todoUpdateDto.getDescription())
+            .todoType(todoUpdateDto.getTodoType())
             .todoDate(currentDate)
-            .indexColor(todoCreateDto.getIndexColor())
+            .indexColor(todoUpdateDto.getIndexColor())
             .isCompleted(false)
             .todoRepeat(todoRepeatEntity)
             .build();


### PR DESCRIPTION
# 변경사항
### AS-IS
- **투두 목록 조회 시 indexColor 미포함**

- **투두 수정 시 시작 날짜 포함 : 필요하지 않음**

<br><br>

### TO-BE
**투두 목록 조회 시 indexColor 포함**
- TodoResponseDto : indexColor 필드 추가
- TodoService : getTodos()의 return문 수정

<br>

**투두 수정 시 시작 날짜 삭제**
- TodoUpdateDto 추가 : title, todoType, isRoutine, indexColor, endDate, description, repeatDays
- TodoController : changeTodo()의 TodoCreateDto를 TodoUpdateDto로 변경
- TodoService
  - changeTodo() 
    - TodoCreateDto를 TodoUpdateDto로 변경
    - 시작 날짜와 종료 날짜를 비교하여 종료 날짜가 시작 날짜보다 앞서지 않도록 하는 조건문 삭제 (시작 날짜를 받지 않게 수정하였기 때문)
    - newTodoRepeatEntity 생성 시 startDate에는 기존의 TodoEntity의 todoDate를 값으로 받도록 함
  - updateTodoEntity() : TodoCreateDto를 TodoUpdateDto로 변경
  - createTodosForRepeatDays()
    - TodoCreateDto를 TodoUpdateDto로 변경
    - currentDate를 excludedDate로 설정하여 excludedDate 이후의 날짜만 새로 생성하도록 설정 (excludedDate = 수정하려는 todoEntity의 todoDate)


<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드