### PR TITLE
검색 기능 구현

### DIFF
--- a/src/main/java/plannery/flora/config/SecurityConfig.java
+++ b/src/main/java/plannery/flora/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
             .requestMatchers("/notifications/**").hasRole("ADMIN")
 
             .requestMatchers("/members/**").hasRole("MEMBER")
+            .requestMatchers("/search/**").hasRole("MEMBER")
 
             .anyRequest().authenticated())
 

--- a/src/main/java/plannery/flora/controller/SearchController.java
+++ b/src/main/java/plannery/flora/controller/SearchController.java
@@ -1,0 +1,34 @@
+package plannery.flora.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import plannery.flora.dto.search.SearchResultDto;
+import plannery.flora.service.SearchService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search")
+public class SearchController {
+
+  private final SearchService searchService;
+
+  /**
+   * 키워드 검색
+   *
+   * @param keyword     키워드
+   * @param userDetails 사용자 정보
+   * @return List<SearchResultDto> : path, title
+   */
+  @GetMapping
+  public ResponseEntity<List<SearchResultDto>> search(@RequestParam String keyword,
+      @AuthenticationPrincipal UserDetails userDetails) {
+    return ResponseEntity.ok(searchService.search(userDetails, keyword));
+  }
+}

--- a/src/main/java/plannery/flora/dto/search/SearchResultDto.java
+++ b/src/main/java/plannery/flora/dto/search/SearchResultDto.java
@@ -1,0 +1,17 @@
+package plannery.flora.dto.search;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchResultDto {
+
+  private String path;
+  
+  private String title;
+}

--- a/src/main/java/plannery/flora/repository/DiaryRepository.java
+++ b/src/main/java/plannery/flora/repository/DiaryRepository.java
@@ -16,4 +16,7 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
 
   @Query("SELECT CASE WHEN COUNT(d) > 0 THEN true ELSE false END FROM DiaryEntity d WHERE d.member.id = :memberId AND d.date = :date")
   boolean existsByMemberIdAndDate(@Param("memberId") Long memberId, @Param("date") LocalDate date);
+
+  List<DiaryEntity> findByMemberIdAndTitleContainingOrMemberIdAndContentContaining(
+      Long memberId1, String keyword1, Long memberId2, String keyword2);
 }

--- a/src/main/java/plannery/flora/repository/EventRepository.java
+++ b/src/main/java/plannery/flora/repository/EventRepository.java
@@ -13,12 +13,10 @@ public interface EventRepository extends JpaRepository<EventEntity, Long> {
 
   List<EventEntity> findAllByMemberId(Long memberId);
 
-
   List<EventEntity> findAllByMemberIdAndStartDateTimeLessThanEqualAndEndDateTimeGreaterThanEqualOrStartDateTimeBetweenOrEndDateTimeBetween(
       Long memberId, LocalDateTime startOfDay, LocalDateTime endOfDay,
       LocalDateTime startRange1, LocalDateTime endRange1,
       LocalDateTime startRange2, LocalDateTime endRange2);
-
 
   @Query("SELECT e FROM EventEntity e WHERE e.member.id = :memberId " +
       "AND (e.startDateTime <= :endDate AND e.endDateTime >= :startDate)")
@@ -29,4 +27,7 @@ public interface EventRepository extends JpaRepository<EventEntity, Long> {
   @Query("SELECT e FROM EventEntity e WHERE e.member.id = :memberId AND e.isDDay = true AND e.startDateTime >= :todayStartOfDay")
   List<EventEntity> findDDayEventsByMemberId(@Param("memberId") Long memberId,
       @Param("todayStartOfDay") LocalDateTime todayStartOfDay);
+
+  List<EventEntity> findByMemberIdAndTitleContainingOrMemberIdAndDescriptionContaining(
+      Long memberId1, String keyword1, Long memberId2, String keyword2);
 }

--- a/src/main/java/plannery/flora/repository/PromiseRepository.java
+++ b/src/main/java/plannery/flora/repository/PromiseRepository.java
@@ -1,5 +1,6 @@
 package plannery.flora.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -12,4 +13,6 @@ public interface PromiseRepository extends JpaRepository<PromiseEntity, Long> {
 
   @Query("SELECT p FROM PromiseEntity p WHERE p.member.id = :memberId")
   Optional<PromiseEntity> findByMemberId(@Param("memberId") Long memberId);
+
+  List<PromiseEntity> findByMemberIdAndContentContaining(Long memberId, String keyword);
 }

--- a/src/main/java/plannery/flora/repository/TodoRepository.java
+++ b/src/main/java/plannery/flora/repository/TodoRepository.java
@@ -13,8 +13,6 @@ import plannery.flora.enums.TodoType;
 @Repository
 public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
 
-  List<TodoEntity> findAllByMemberId(Long memberId);
-
   List<TodoEntity> findAllByTodoRepeat(TodoRepeatEntity todoRepeatEntity);
 
   @Query("SELECT t FROM TodoEntity t " +
@@ -32,4 +30,7 @@ public interface TodoRepository extends JpaRepository<TodoEntity, Long> {
   @Query("SELECT t FROM TodoEntity t WHERE t.member.id = :memberId AND t.todoDate = :today")
   List<TodoEntity> findTodosByDate(@Param("memberId") Long memberId,
       @Param("today") LocalDate today);
+
+  List<TodoEntity> findByMemberIdAndTitleContainingOrMemberIdAndDescriptionContaining(
+      Long memberId1, String keyword1, Long memberId2, String keyword2);
 }

--- a/src/main/java/plannery/flora/service/SearchService.java
+++ b/src/main/java/plannery/flora/service/SearchService.java
@@ -1,0 +1,90 @@
+package plannery.flora.service;
+
+import static plannery.flora.exception.ErrorCode.MEMBER_NOT_FOUND;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import plannery.flora.dto.search.SearchResultDto;
+import plannery.flora.entity.DiaryEntity;
+import plannery.flora.entity.EventEntity;
+import plannery.flora.entity.MemberEntity;
+import plannery.flora.entity.PromiseEntity;
+import plannery.flora.entity.TodoEntity;
+import plannery.flora.exception.CustomException;
+import plannery.flora.repository.DiaryRepository;
+import plannery.flora.repository.EventRepository;
+import plannery.flora.repository.MemberRepository;
+import plannery.flora.repository.PromiseRepository;
+import plannery.flora.repository.TodoRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+  private final DiaryRepository diaryRepository;
+  private final EventRepository eventRepository;
+  private final PromiseRepository promiseRepository;
+  private final TodoRepository todoRepository;
+  private final MemberRepository memberRepository;
+
+  /**
+   * 키워드 검색 : 일기, 이벤트, 목표/다짐, 투두
+   *
+   * @param userDetails 사용자 정보
+   * @param keyword     키워드
+   * @return List<SearchResultDto> : path, title
+   */
+  public List<SearchResultDto> search(UserDetails userDetails, String keyword) {
+    MemberEntity member = memberRepository.findByEmail(userDetails.getUsername())
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+    Long memberId = member.getId();
+
+    List<SearchResultDto> results = new ArrayList<>();
+
+    // 일기
+    List<DiaryEntity> diaries = diaryRepository.findByMemberIdAndTitleContainingOrMemberIdAndContentContaining(
+        memberId, keyword, memberId, keyword);
+    for (DiaryEntity diary : diaries) {
+      results.add(SearchResultDto.builder()
+          .path("캘린더 > 오늘의 일기")
+          .title(diary.getTitle())
+          .build());
+    }
+
+    // 이벤트
+    List<EventEntity> events = eventRepository.findByMemberIdAndTitleContainingOrMemberIdAndDescriptionContaining(
+        memberId, keyword, memberId, keyword);
+    for (EventEntity event : events) {
+      results.add(SearchResultDto.builder()
+          .path("캘린더 > 이벤트")
+          .title(event.getTitle())
+          .build());
+    }
+
+    // 목표/다짐
+    List<PromiseEntity> promises = promiseRepository.findByMemberIdAndContentContaining(memberId,
+        keyword);
+    for (PromiseEntity promise : promises) {
+      results.add(SearchResultDto.builder()
+          .path("대시보드 > 목표/다짐")
+          .title(promise.getContent())
+          .build());
+    }
+
+    // 투두
+    List<TodoEntity> todos = todoRepository.findByMemberIdAndTitleContainingOrMemberIdAndDescriptionContaining(
+        memberId, keyword, memberId, keyword);
+    for (TodoEntity todo : todos) {
+      results.add(SearchResultDto.builder()
+          .path("캘린더 > Todolist")
+          .title(todo.getTitle())
+          .build());
+    }
+
+    return results;
+  }
+}


### PR DESCRIPTION
# 변경사항
### AS-IS
- **검색 기능 부재**
 
<br><br>

### TO-BE
**검색 기능 구현**
- **api : https://flora-life.link/search**
- param : keyword (e.g. https://flora-life.link/search?keyword=중간고사)
- header : Bearer Token 필요
- response : 
  ```java
  [
    {
        "path": "캘린더 > 오늘의 일기",
        "title": "중간고사 준비 시작!",
        "id": 1
    },
    {
        "path": "캘린더 > 이벤트",
        "title": "중간고사",
        "id": 1
    },
    {
        "path": "대시보드 > 목표/다짐",
        "title": "중간고사 화이팅",
        "id": 1
    },
    {
        "path": "캘린더 > Todolist",
        "title": "투두 제목",
        "id": 1
    },
    {
        "path": "캘린더 > Todolist",
        "title": "투두 제목",
        "id": 2
    },
    {
        "path": "캘린더 > Todolist",
        "title": "투두 제목",
        "id": 3
    },
    {
        "path": "캘린더 > Todolist",
        "title": "투두 제목",
        "id": 4
    },
    {
        "path": "캘린더 > Todolist",
        "title": "중간고사",
        "id": 5
    }
  ]
  ```
- SearchResponseDto 추가 : path(String), title(String), id(Long)
- SearchController & SearchService 추가
  - 오늘의 일기, 목표/다짐, 투두리스트, 이벤트 중 키워드를 포함한 Entity를 조회하여 Dto로 변환하여 리턴
    - 오늘의 일기 : 제목 or 내용에 포함할 경우
    - 투두리스트 : 제목 or 메모에 포함할 경우
    - 목표/다짐 : 내용에 포함할 경우
    - 이벤트 : 제목 or 메모에 포함할 경우


<br><br>

### Test
- [X] API 테스트
- [ ] 테스트 코드